### PR TITLE
Migrate Azure Cloud Connector Adapter from Freyja repo

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
-      - name: Run doctest only
+      - name: Run doctest
         uses: actions-rs/cargo@v1
         with:
           command: test

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -44,17 +44,11 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
-      # This step is currently turned off because the command will fail.
-      # Doc tests are only run against library targets, not binaries.
-      # The only targets currently in the repo are binary targets,
-      # so the command fails with the error message "no library targets found".
-      # This can likely be re-enabled if libraries are added to the repo.
-      # See https://github.com/rust-lang/rust/issues/50784
-      # - name: Run doctest only
-      #   uses: actions-rs/cargo@v1
-      #   with:
-      #     command: test
-      #     args: --workspace --doc
+      - name: Run doctest only
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace --doc
       - name: Run cargo doc
         # This step is required to detect possible errors in docs that are not doctests.
         uses: actions-rs/cargo@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "azure-cloud-connector-adapter"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "azure-cloud-connector-proto",
+ "freyja-common",
+ "freyja-contracts",
+ "futures",
+ "log",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tokio-stream",
+ "tonic 0.10.0",
+ "tower",
+]
+
+[[package]]
 name = "azure-cloud-connector-proto"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,10 @@
 # The default resolver for workspaces is different than for regular packages, so use v2 to avoid warnings
 resolver = "2"
 members = [
-    "freyja_apps/in_memory",
     "cloud_connectors/azure/mqtt_connector",
     "cloud_connectors/azure/proto-build",
+    "freyja_adapters/cloud/azure_cloud_adapter",
+    "freyja_apps/in_memory",
 ]
 
 [workspace.dependencies]
@@ -19,6 +20,7 @@ azure-cloud-connector-proto = { path = "cloud_connectors/azure/proto-build" }
 # Versioning is managed by the Cargo.lock file rather than copying rev properties to all of these
 freyja = { git = "https://github.com/eclipse-ibeji/freyja" }
 freyja-common = { git = "https://github.com/eclipse-ibeji/freyja" }
+freyja-contracts = { git = "https://github.com/eclipse-ibeji/freyja" }
 in-memory-mock-cloud-adapter = { git = "https://github.com/eclipse-ibeji/freyja" }
 in-memory-mock-digital-twin-adapter = { git = "https://github.com/eclipse-ibeji/freyja" }
 in-memory-mock-mapping-client = { git = "https://github.com/eclipse-ibeji/freyja" }
@@ -33,7 +35,9 @@ paho-mqtt = "0.12.1"
 prost = "0.12.0"
 serde = "1.0.188"
 serde_json = "1.0.106"
+tempfile = "3.8.0"
 time = "0.3.28"
 tokio = "1.32.0"
 tonic = "0.10.0"
 tonic-build = "0.10.0"
+tower = "0.4.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 members = [
     "cloud_connectors/azure/mqtt_connector",
     "cloud_connectors/azure/proto-build",
-    "freyja_adapters/cloud/azure_cloud_adapter",
+    "freyja_adapters/cloud/azure_cloud_connector_adapter",
     "freyja_apps/in_memory",
 ]
 
@@ -38,6 +38,7 @@ serde_json = "1.0.106"
 tempfile = "3.8.0"
 time = "0.3.28"
 tokio = "1.32.0"
+tokio-stream = "0.1.14"
 tonic = "0.10.0"
 tonic-build = "0.10.0"
 tower = "0.4.13"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ Coming soon!
 
 The Freyja examples include:
 
-- [Example Freyja Apps](./freyja_apps/): These are examples of how to write a Freyja application using its plugin model. Each example will have a README describing its usage, and the `template` app can be used to get started with your own adapters.
-- [Example Freyja Adapters](./freyja_adapters/): These are examples of adapters that can be used with Freyja. Each adapter will have a README describing its usage.
+- [Example Freyja Apps](./freyja_apps/): These are examples of how to write a Freyja application using its plugin model. Each example has a README describing its usage, and the `template` app can be used to get started with your own adapters.
+- [Example Freyja Adapters](./freyja_adapters/): These are examples of adapters that can be used with Freyja. Each adapter has a README describing its usage.
 - [Example Cloud Connectors](./cloud_connectors/): These are examples of cloud connectors that Freyja can interface with through the `CloudAdapter` trait. These serve as examples of how to integrate with specific cloud solutions.

--- a/README.md
+++ b/README.md
@@ -16,5 +16,6 @@ Coming soon!
 
 The Freyja examples include:
 
-- [Example Freyja apps](./freyja_apps/): These are examples of how to write a Freyja application using its plugin model. Each example has a README describing its usage, and the `template` app can be used to get started with your own adapters.
-- Freyja Adapters: Coming soon!
+- [Example Freyja Apps](./freyja_apps/): These are examples of how to write a Freyja application using its plugin model. Each example will have a README describing its usage, and the `template` app can be used to get started with your own adapters.
+- [Example Freyja Adapters](./freyja_adapters/): These are examples of adapters that can be used with Freyja. Each adapter will have a README describing its usage.
+- [Example Cloud Connectors](./cloud_connectors/): These are examples of cloud connectors that Freyja can interface with through the `CloudAdapter` trait. These serve as examples of how to integrate with specific cloud solutions.

--- a/freyja_adapters/cloud/azure_cloud_connector_adapter/Cargo.toml
+++ b/freyja_adapters/cloud/azure_cloud_connector_adapter/Cargo.toml
@@ -1,0 +1,24 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+# SPDX-License-Identifier: MIT
+
+[package]
+name = "azure-cloud-connector-adapter"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+
+[dependencies]
+async-trait = { workspace = true }
+azure-cloud-connector-proto = { workspace = true }
+freyja-common = { workspace = true }
+freyja-contracts = { workspace = true }
+futures = { workspace = true }
+log = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tempfile = { workspace = true }
+tonic = { workspace = true }
+tokio = { workspace = true }
+tokio-stream = { workspace = true }
+tower = { workspace = true }

--- a/freyja_adapters/cloud/azure_cloud_connector_adapter/README.md
+++ b/freyja_adapters/cloud/azure_cloud_connector_adapter/README.md
@@ -1,0 +1,19 @@
+# Azure Cloud Connector Adapter
+
+This is an example implementation of an adapter for the [Azure Cloud Connectors](../../../cloud_connectors/azure/README.md).
+
+This adapter is used to communicate with an Azure Cloud Connector to synchronize in-vehicle signals with the cloud.
+
+## Prerequisites
+
+### Azure Cloud Connector
+
+You will need to either have the [Azure Digital Twins Connector](../../../cloud_connectors/azure/digital_twins_connector/README.md) or [Azure MQTT Connector](../../../cloud_connectors/azure/mqtt_connector/README.md) running. This cloud adapter is capable of interfacing with both connectors.
+
+## Configuration
+
+This cloud adapter can be configured using the `res/azure_cloud_connector_adapter_config.json` file. This file is automatically copied to the build output and contains the following properties:
+
+- `cloud_connector_url`: The URL of the cloud connector. This should match the configuration for your cloud connector.
+- `max_retries`: The maximum number of times to retry failed attempts to send data to the cloud connector.
+- `retry_interval_ms`: The duration between retries.

--- a/freyja_adapters/cloud/azure_cloud_connector_adapter/build.rs
+++ b/freyja_adapters/cloud/azure_cloud_connector_adapter/build.rs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+use std::{env, fs, path::Path};
+
+const OUT_DIR: &str = "OUT_DIR";
+const SAMPLE_CONFIG_FILE: &str = "res/azure_cloud_connector_adapter_config.sample.json";
+const CONFIG_FILE: &str = "azure_cloud_connector_adapter_config.json";
+
+fn main() {
+    // The current directory of the build script is the package's root directory
+    let config_path = env::current_dir().unwrap().join(SAMPLE_CONFIG_FILE);
+
+    let target_dir = env::var(OUT_DIR).unwrap();
+    let dest_path = Path::new(&target_dir).join(CONFIG_FILE);
+
+    fs::copy(&config_path, dest_path).unwrap();
+
+    println!("cargo:rerun-if-changed={}", config_path.to_str().unwrap());
+}

--- a/freyja_adapters/cloud/azure_cloud_connector_adapter/res/azure_cloud_connector_adapter_config.sample.json
+++ b/freyja_adapters/cloud/azure_cloud_connector_adapter/res/azure_cloud_connector_adapter_config.sample.json
@@ -1,0 +1,5 @@
+{
+    "max_retries": 5,
+    "retry_interval_ms": 1000,
+    "cloud_connector_url": "http://[::1]:8890"
+}

--- a/freyja_adapters/cloud/azure_cloud_connector_adapter/src/azure_cloud_connector_adapter.rs
+++ b/freyja_adapters/cloud/azure_cloud_connector_adapter/src/azure_cloud_connector_adapter.rs
@@ -1,0 +1,269 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+use std::{env, fs, path::Path, time::Duration};
+
+use async_trait::async_trait;
+use azure_cloud_connector_proto::azure_cloud_connector::{
+    azure_cloud_connector_client::AzureCloudConnectorClient, UpdateDigitalTwinRequest,
+};
+use log::debug;
+use serde::{Deserialize, Serialize};
+use tonic::transport::Channel;
+
+use crate::azure_cloud_connector_adapter_config::{Config, CONFIG_FILE};
+use freyja_common::utils::execute_with_retry;
+use freyja_contracts::cloud_adapter::{
+    CloudAdapter, CloudAdapterError, CloudMessageRequest, CloudMessageResponse,
+};
+
+const MODEL_ID_KEY: &str = "model_id";
+const INSTANCE_ID_KEY: &str = "instance_id";
+const INSTANCE_PROPERTY_PATH_KEY: &str = "instance_property_path";
+
+/// The Cloud Connector Adapter for communicating with the Cloud Connector
+pub struct AzureCloudConnectorAdapter {
+    // A gRPC Client for communicating with the Azure Cloud Connector
+    cloud_connector_client: AzureCloudConnectorClient<Channel>,
+}
+
+/// Contains info about a digital twin instance
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+struct CloudDigitalTwinInstance {
+    /// The id of the target signal's model
+    pub model_id: String,
+
+    /// The id of the target signal's instance
+    pub instance_id: String,
+
+    /// The path of the property within the instance to target
+    pub instance_property_path: String,
+}
+
+impl AzureCloudConnectorAdapter {
+    /// Gets info about an instance from a cloud message
+    ///
+    /// # Arguments
+    /// - `cloud_message`: represents a message to send to the cloud canonical model
+    fn get_instance_info_from_message(
+        cloud_message: &CloudMessageRequest,
+    ) -> Result<CloudDigitalTwinInstance, CloudAdapterError> {
+        Ok(CloudDigitalTwinInstance {
+            model_id: cloud_message
+                .cloud_signal
+                .get(MODEL_ID_KEY)
+                .ok_or_else(|| {
+                    CloudAdapterError::key_not_found(format!("Cannot find key: {MODEL_ID_KEY:}"))
+                })?
+                .clone(),
+            instance_id: cloud_message
+                .cloud_signal
+                .get(INSTANCE_ID_KEY)
+                .ok_or_else(|| {
+                    CloudAdapterError::key_not_found(format!("Cannot find key: {INSTANCE_ID_KEY:}"))
+                })?
+                .clone(),
+            instance_property_path: cloud_message
+                .cloud_signal
+                .get(INSTANCE_PROPERTY_PATH_KEY)
+                .ok_or_else(|| {
+                    CloudAdapterError::key_not_found(format!(
+                        "Cannot find key: {INSTANCE_PROPERTY_PATH_KEY:}"
+                    ))
+                })?
+                .clone(),
+        })
+    }
+}
+
+#[async_trait]
+impl CloudAdapter for AzureCloudConnectorAdapter {
+    /// Creates a new instance of a CloudAdapter with default settings
+    fn create_new() -> Result<Self, CloudAdapterError> {
+        let cloud_connector_client = futures::executor::block_on(async {
+            let config_file = fs::read_to_string(Path::new(env!("OUT_DIR")).join(CONFIG_FILE))
+                .map_err(CloudAdapterError::io)?;
+            // Load the config
+            let config: Config =
+                serde_json::from_str(&config_file).map_err(CloudAdapterError::deserialize)?;
+
+            execute_with_retry(
+                config.max_retries,
+                Duration::from_millis(config.retry_interval_ms),
+                || AzureCloudConnectorClient::connect(config.cloud_connector_url.clone()),
+                Some(String::from(
+                    "Connection retry for connecting to Azure Cloud Connector",
+                )),
+            )
+            .await
+            .map_err(CloudAdapterError::communication)
+        })?;
+
+        Ok(Self {
+            cloud_connector_client,
+        })
+    }
+
+    /// Sends the signal to the cloud
+    ///
+    /// # Arguments
+    /// - `cloud_message`: represents a message to send to the cloud canonical model
+    async fn send_to_cloud(
+        &self,
+        cloud_message: CloudMessageRequest,
+    ) -> Result<CloudMessageResponse, CloudAdapterError> {
+        debug!("Received a request to send to the cloud");
+        let cloud_message_string =
+            serde_json::to_string_pretty(&cloud_message).map_err(CloudAdapterError::serialize)?;
+        debug!("Cloud canonical value:\n{cloud_message_string}");
+
+        let cloud_digital_twin_instance = Self::get_instance_info_from_message(&cloud_message)?;
+
+        let request = tonic::Request::new(UpdateDigitalTwinRequest {
+            model_id: cloud_digital_twin_instance.model_id,
+            instance_id: cloud_digital_twin_instance.instance_id,
+            instance_property_path: cloud_digital_twin_instance.instance_property_path,
+            data: cloud_message.signal_value,
+        });
+
+        let response = self
+            .cloud_connector_client
+            .clone()
+            .update_digital_twin(request)
+            .await
+            .map_err(CloudAdapterError::communication)?;
+        debug!("Response from cloud connector {response:?}");
+
+        Ok(CloudMessageResponse {})
+    }
+}
+
+#[cfg(test)]
+mod azure_cloud_connector_tests {
+    use super::*;
+
+    use std::collections::HashMap;
+
+    #[tokio::test]
+    async fn get_instance_info_from_message_test() {
+        let cloud_message = CloudMessageRequest {
+            cloud_signal: HashMap::new(),
+            signal_value: String::new(),
+            signal_timestamp: String::new(),
+        };
+        let cloud_digital_twin_instance =
+            AzureCloudConnectorAdapter::get_instance_info_from_message(&cloud_message);
+        assert!(cloud_digital_twin_instance.is_err());
+
+        let mut cloud_signal_map = HashMap::new();
+        cloud_signal_map.insert(String::from(MODEL_ID_KEY), String::from("some-model-id"));
+        cloud_signal_map.insert(
+            String::from(INSTANCE_ID_KEY),
+            String::from("some-instance-id"),
+        );
+        cloud_signal_map.insert(
+            String::from(INSTANCE_PROPERTY_PATH_KEY),
+            String::from("some-instance-property-path"),
+        );
+    }
+
+    /// The tests below uses Unix sockets to create a channel between a gRPC client and a gRPC server.
+    /// Unix sockets are more ideal than using TCP/IP sockets since Rust tests will run in parallel
+    /// so you would need to set an arbitrary port per test for TCP/IP sockets.
+    #[cfg(unix)]
+    mod unix_tests {
+        use super::*;
+
+        use std::sync::Arc;
+
+        use azure_cloud_connector_proto::azure_cloud_connector::azure_cloud_connector_server::{
+            AzureCloudConnector, AzureCloudConnectorServer,
+        };
+        use azure_cloud_connector_proto::azure_cloud_connector::UpdateDigitalTwinResponse;
+        use tempfile::TempPath;
+        use tokio::net::{UnixListener, UnixStream};
+        use tokio_stream::wrappers::UnixListenerStream;
+        use tonic::transport::{Channel, Endpoint, Server, Uri};
+        use tonic::{Request, Response, Status};
+        use tower::service_fn;
+
+        pub struct MockAzureConnector {}
+
+        #[tonic::async_trait]
+        impl AzureCloudConnector for MockAzureConnector {
+            /// Updates a digital twin instance
+            ///
+            /// # Arguments
+            /// - `request`: the request to send
+            async fn update_digital_twin(
+                &self,
+                _request: Request<UpdateDigitalTwinRequest>,
+            ) -> Result<Response<UpdateDigitalTwinResponse>, Status> {
+                let response = UpdateDigitalTwinResponse {
+                    reply: String::new(),
+                };
+                Ok(Response::new(response))
+            }
+        }
+
+        async fn create_test_grpc_client(
+            bind_path: Arc<TempPath>,
+        ) -> AzureCloudConnectorClient<Channel> {
+            let channel = Endpoint::try_from("http://URI_IGNORED") // Devskim: ignore DS137138
+                .unwrap()
+                .connect_with_connector(service_fn(move |_: Uri| {
+                    let bind_path = bind_path.clone();
+                    async move { UnixStream::connect(bind_path.as_ref()).await }
+                }))
+                .await
+                .unwrap();
+
+            AzureCloudConnectorClient::new(channel)
+        }
+
+        async fn run_test_grpc_server(uds_stream: UnixListenerStream) {
+            let mock_azure_connector = MockAzureConnector {};
+            Server::builder()
+                .add_service(AzureCloudConnectorServer::new(mock_azure_connector))
+                .serve_with_incoming(uds_stream)
+                .await
+                .unwrap();
+        }
+
+        #[tokio::test]
+        async fn send_request_to_provider() {
+            // Create the Unix Socket
+            let bind_path = Arc::new(tempfile::NamedTempFile::new().unwrap().into_temp_path());
+            let uds = match UnixListener::bind(bind_path.as_ref()) {
+                Ok(unix_listener) => unix_listener,
+                Err(_) => {
+                    std::fs::remove_file(bind_path.as_ref()).unwrap();
+                    UnixListener::bind(bind_path.as_ref()).unwrap()
+                }
+            };
+            let uds_stream = UnixListenerStream::new(uds);
+
+            let request_future = async {
+                let mut client = create_test_grpc_client(bind_path.clone()).await;
+
+                let request = tonic::Request::new(UpdateDigitalTwinRequest {
+                    model_id: String::from(
+                        "dtmi:sdv:Cloud:Vehicle:Cabin:HVAC:AmbientAirTemperature;1",
+                    ),
+                    instance_id: String::from("hvac"),
+                    instance_property_path: String::from("/AmbientAirTemperature"),
+                    data: String::from("12.00"),
+                });
+                assert!(client.update_digital_twin(request).await.is_ok())
+            };
+
+            tokio::select! {
+                _ = run_test_grpc_server(uds_stream) => (),
+                _ = request_future => ()
+            }
+
+            std::fs::remove_file(bind_path.as_ref()).unwrap();
+        }
+    }
+}

--- a/freyja_adapters/cloud/azure_cloud_connector_adapter/src/azure_cloud_connector_adapter_config.rs
+++ b/freyja_adapters/cloud/azure_cloud_connector_adapter/src/azure_cloud_connector_adapter_config.rs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+use serde::{Deserialize, Serialize};
+
+pub(crate) const CONFIG_FILE: &str = "azure_cloud_connector_adapter_config.json";
+
+/// A config entry for the Azure Cloud Connector Adapter
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Config {
+    /// Max retries for connecting to an Azure Cloud Connector
+    pub max_retries: u32,
+
+    /// Retry interval in milliseconds
+    pub retry_interval_ms: u64,
+
+    /// The url for the cloud connector server
+    pub cloud_connector_url: String,
+}

--- a/freyja_adapters/cloud/azure_cloud_connector_adapter/src/lib.rs
+++ b/freyja_adapters/cloud/azure_cloud_connector_adapter/src/lib.rs
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+pub mod azure_cloud_connector_adapter;
+mod azure_cloud_connector_adapter_config;

--- a/freyja_apps/template/README.md
+++ b/freyja_apps/template/README.md
@@ -1,6 +1,6 @@
 # Freyja App Template
 
-This is a template for creating a Freyja application. For more information about writing Freyja applications, see the [Freyja documentation on the subject](https://github.com/eclipse-ibeji/freyja/blob/main/docs/custom-adapters.md).
+This is a template for creating a Freyja application. For more information about writing Freyja applications, see the [Freyja documentation on custom adapters](https://github.com/eclipse-ibeji/freyja/blob/main/docs/custom-adapters.md).
 
 ## Instructions
 
@@ -8,8 +8,8 @@ To create your own Freyja application, you can copy this template and make the f
 
 1. Choose the adapters to use. Freyja requires users to select a Cloud Adapter, a Digital Twin Adapter, and a Mapping Client. Some potential choices are:
     1. Freyja mocks. These are enumerated [here](https://github.com/eclipse-ibeji/freyja/blob/main/docs/quickstart.md#appendix-a) and are generally only suitable for tests or demos.
-    1. Example adapters from this repository (coming soon!).
-    1. A custom adapter implementation.
+    1. [Example adapters from this repository](../../freyja_adapters/).
+    1. A custom adapter implementation. For more information on how to write and use these, see the see the [Freyja documentation on custom adapters](https://github.com/eclipse-ibeji/freyja/blob/main/docs/custom-adapters.md).
 1. Edit `Cargo.template.toml`:
     1. Add dependencies for the package(s) you need for your adapters. You can implement adapters in the same crate and import their dependencies here, or you can implement them in separate crates and import those.
     1. Update the package name and version as desired.


### PR DESCRIPTION
Migrates the `AzureCloudConnectorAdapter` from the Freyja repo and makes doc/config updates as necessary