### PR TITLE
Migrate Ibeji Adapter from Freyja repo

### DIFF
--- a/.freyja/config/mock_mapping_config.json
+++ b/.freyja/config/mock_mapping_config.json
@@ -1,0 +1,52 @@
+{
+    "values": [
+        {
+            "begin": 2,
+            "end": null,
+            "value": {
+                "source": "dtmi:sdv:HVAC:AmbientAirTemperature;1",
+                "target": {
+                    "model_id": "dtmi:sdv:Cloud:Vehicle:Cabin:HVAC:AmbientAirTemperature;1",
+                    "instance_id": "hvac",
+                    "instance_property_path": "/AmbientAirTemperature"
+                },
+                "interval_ms": 3000,
+                "conversion": {
+                    "mul": 0.5556,
+                    "offset": -17.7778
+                },
+                "emit_on_change": false
+            }
+        },
+        {
+            "begin": 2,
+            "end": null,
+            "value": {
+                "source": "dtmi:sdv:HVAC:IsAirConditioningActive;1",
+                "target": {
+                    "model_id": "dtmi:sdv:Cloud:Vehicle:Cabin:HVAC:IsAirConditioningActive;1",
+                    "instance_id": "hvac",
+                    "instance_property_path": "/IsAirConditioningActive"
+                },
+                "interval_ms": 5000,
+                "conversion": null,
+                "emit_on_change": false
+            }
+        },
+        {
+            "begin": 4,
+            "end": null,
+            "value": {
+                "source": "dtmi:sdv:OBD:HybridBatteryRemaining;1",
+                "target": {
+                    "model_id": "dtmi:sdv:Cloud:Vehicle:OBD:HybridBatteryRemaining;1",
+                    "instance_id": "obd",
+                    "instance_property_path": "/HybridBatteryRemaining"
+                },
+                "interval_ms": 2000,
+                "conversion": null,
+                "emit_on_change": false
+            }
+        }
+    ]
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,6 +187,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "414dcefbc63d77c526a76b3afcf6fbb9b5e2791c19c3aa2297733208750c6e53"
@@ -191,6 +208,15 @@ name = "bitflags"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bumpalo"
@@ -238,6 +264,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "config"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d379af7f68bfc21714c6c7dea883544201741d2ce8274bb12fa54f89507f52a7"
+dependencies = [
+ "async-trait",
+ "json5",
+ "lazy_static",
+ "nom",
+ "pathdiff",
+ "ron",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "toml",
+ "yaml-rust",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,6 +318,15 @@ dependencies = [
  "tokio",
  "tonic",
  "tonic-build",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -343,10 +397,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 
 [[package]]
 name = "either"
@@ -454,7 +534,7 @@ dependencies = [
 [[package]]
 name = "freyja"
 version = "0.1.0"
-source = "git+https://github.com/eclipse-ibeji/freyja#a07b03349d23b14d0c215ace341e05d9e4e5195e"
+source = "git+https://github.com/eclipse-ibeji/freyja#71841353eaa1fba745447911e05dba6ce890ca69"
 dependencies = [
  "async-trait",
  "crossbeam",
@@ -469,19 +549,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "freyja-build-common"
+version = "0.1.0"
+source = "git+https://github.com/eclipse-ibeji/freyja#71841353eaa1fba745447911e05dba6ce890ca69"
+
+[[package]]
 name = "freyja-common"
 version = "0.1.0"
-source = "git+https://github.com/eclipse-ibeji/freyja#a07b03349d23b14d0c215ace341e05d9e4e5195e"
+source = "git+https://github.com/eclipse-ibeji/freyja#71841353eaa1fba745447911e05dba6ce890ca69"
 dependencies = [
+ "config",
  "freyja-contracts",
+ "home",
  "log",
+ "serde",
+ "serde_json",
  "tokio",
 ]
 
 [[package]]
 name = "freyja-contracts"
 version = "0.1.0"
-source = "git+https://github.com/eclipse-ibeji/freyja#a07b03349d23b14d0c215ace341e05d9e4e5195e"
+source = "git+https://github.com/eclipse-ibeji/freyja#71841353eaa1fba745447911e05dba6ce890ca69"
 dependencies = [
  "async-trait",
  "crossbeam",
@@ -499,8 +588,8 @@ name = "freyja-e2e-app"
 version = "0.1.0"
 dependencies = [
  "freyja",
+ "ibeji-adapter",
  "in-memory-mock-cloud-adapter",
- "in-memory-mock-digital-twin-adapter",
  "in-memory-mock-mapping-client",
  "tokio",
 ]
@@ -612,6 +701,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -631,15 +730,19 @@ checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 [[package]]
 name = "grpc-provider-proxy-v1"
 version = "0.1.0"
-source = "git+https://github.com/eclipse-ibeji/freyja#a07b03349d23b14d0c215ace341e05d9e4e5195e"
+source = "git+https://github.com/eclipse-ibeji/freyja#71841353eaa1fba745447911e05dba6ce890ca69"
 dependencies = [
  "async-trait",
  "crossbeam",
+ "freyja-build-common",
+ "freyja-common",
  "freyja-contracts",
  "futures",
  "log",
  "proc-macros",
  "samples-protobuf-data-access",
+ "serde",
+ "serde_json",
  "tempfile",
  "tokio",
  "tokio-stream",
@@ -671,6 +774,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -724,7 +830,7 @@ dependencies = [
 [[package]]
 name = "http-mock-provider-proxy"
 version = "0.1.0"
-source = "git+https://github.com/eclipse-ibeji/freyja#a07b03349d23b14d0c215ace341e05d9e4e5195e"
+source = "git+https://github.com/eclipse-ibeji/freyja#71841353eaa1fba745447911e05dba6ce890ca69"
 dependencies = [
  "async-trait",
  "axum",
@@ -845,7 +951,7 @@ dependencies = [
 [[package]]
 name = "in-memory-mock-cloud-adapter"
 version = "0.1.0"
-source = "git+https://github.com/eclipse-ibeji/freyja#a07b03349d23b14d0c215ace341e05d9e4e5195e"
+source = "git+https://github.com/eclipse-ibeji/freyja#71841353eaa1fba745447911e05dba6ce890ca69"
 dependencies = [
  "async-trait",
  "freyja-contracts",
@@ -859,7 +965,7 @@ dependencies = [
 [[package]]
 name = "in-memory-mock-digital-twin-adapter"
 version = "0.1.0"
-source = "git+https://github.com/eclipse-ibeji/freyja#a07b03349d23b14d0c215ace341e05d9e4e5195e"
+source = "git+https://github.com/eclipse-ibeji/freyja#71841353eaa1fba745447911e05dba6ce890ca69"
 dependencies = [
  "async-trait",
  "freyja-contracts",
@@ -871,9 +977,11 @@ dependencies = [
 [[package]]
 name = "in-memory-mock-mapping-client"
 version = "0.1.0"
-source = "git+https://github.com/eclipse-ibeji/freyja#a07b03349d23b14d0c215ace341e05d9e4e5195e"
+source = "git+https://github.com/eclipse-ibeji/freyja#71841353eaa1fba745447911e05dba6ce890ca69"
 dependencies = [
  "async-trait",
+ "freyja-build-common",
+ "freyja-common",
  "freyja-contracts",
  "serde",
  "serde_json",
@@ -883,7 +991,7 @@ dependencies = [
 [[package]]
 name = "in-memory-mock-provider-proxy"
 version = "0.1.0"
-source = "git+https://github.com/eclipse-ibeji/freyja#a07b03349d23b14d0c215ace341e05d9e4e5195e"
+source = "git+https://github.com/eclipse-ibeji/freyja#71841353eaa1fba745447911e05dba6ce890ca69"
 dependencies = [
  "async-trait",
  "crossbeam",
@@ -959,6 +1067,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,6 +1088,12 @@ name = "libc"
 version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1010,6 +1135,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1032,7 +1163,7 @@ dependencies = [
 [[package]]
 name = "mock-digital-twin"
 version = "0.1.0"
-source = "git+https://github.com/eclipse-ibeji/freyja#a07b03349d23b14d0c215ace341e05d9e4e5195e"
+source = "git+https://github.com/eclipse-ibeji/freyja#71841353eaa1fba745447911e05dba6ce890ca69"
 dependencies = [
  "async-trait",
  "axum",
@@ -1067,6 +1198,16 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1139,6 +1280,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-multimap"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
 name = "paho-mqtt"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1165,10 +1316,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+
+[[package]]
+name = "pest"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c022f1e7b65d6a24c0dbbd5fb344c66881bc01f3e5ae74a1c8100f2f985d98a4"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35513f630d46400a977c4cb58f78e1bfbe01434316e60c37d27b9ad6139c66d8"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc9fc1b9e7057baba189b5c626e2d6f40681ae5b6eb064dc7c7834101ec8123a"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.31",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df74e9e7ec4053ceb980e7c0c8bd3594e977fde1af91daba9c928e8e8c6708d"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "petgraph"
@@ -1246,7 +1448,7 @@ dependencies = [
 [[package]]
 name = "proc-macros"
 version = "0.1.0"
-source = "git+https://github.com/eclipse-ibeji/freyja#a07b03349d23b14d0c215ace341e05d9e4e5195e"
+source = "git+https://github.com/eclipse-ibeji/freyja#71841353eaa1fba745447911e05dba6ce890ca69"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -1311,7 +1513,7 @@ dependencies = [
 [[package]]
 name = "provider-proxy-selector"
 version = "0.1.0"
-source = "git+https://github.com/eclipse-ibeji/freyja#a07b03349d23b14d0c215ace341e05d9e4e5195e"
+source = "git+https://github.com/eclipse-ibeji/freyja#71841353eaa1fba745447911e05dba6ce890ca69"
 dependencies = [
  "async-trait",
  "crossbeam",
@@ -1409,7 +1611,7 @@ version = "0.11.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
 dependencies = [
- "base64",
+ "base64 0.21.3",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1438,6 +1640,27 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "ron"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a"
+dependencies = [
+ "base64 0.13.1",
+ "bitflags 1.3.2",
+ "serde",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -1584,6 +1807,17 @@ dependencies = [
  "tokio",
  "tonic",
  "tonic-build",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1810,6 +2044,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "tonic"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1817,7 +2060,7 @@ checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
 dependencies = [
  "async-trait",
  "axum",
- "base64",
+ "base64 0.21.3",
  "bytes",
  "futures-core",
  "futures-util",
@@ -1922,6 +2165,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1964,6 +2219,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "want"
@@ -2173,4 +2434,13 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,28 +44,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-stream"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.31",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,7 +124,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
- "tonic 0.10.0",
+ "tonic",
  "tower",
 ]
 
@@ -154,10 +132,10 @@ dependencies = [
 name = "azure-cloud-connector-proto"
 version = "0.1.0"
 dependencies = [
- "prost 0.12.0",
+ "prost",
  "tokio",
- "tonic 0.10.0",
- "tonic-build 0.10.0",
+ "tonic",
+ "tonic-build",
 ]
 
 [[package]]
@@ -172,13 +150,13 @@ dependencies = [
  "log",
  "paho-mqtt",
  "proc-macros",
- "prost 0.12.0",
+ "prost",
  "serde",
  "serde_json",
  "time",
  "tokio",
- "tonic 0.10.0",
- "tonic-build 0.10.0",
+ "tonic",
+ "tonic-build",
 ]
 
 [[package]]
@@ -283,6 +261,19 @@ name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+
+[[package]]
+name = "core-protobuf-data-access"
+version = "0.1.0"
+source = "git+https://github.com/eclipse-ibeji/ibeji#370a4f5ae529239607a383f5260966959f55cf3f"
+dependencies = [
+ "prost",
+ "prost-types",
+ "serde",
+ "tokio",
+ "tonic",
+ "tonic-build",
+]
 
 [[package]]
 name = "crossbeam"
@@ -641,7 +632,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
- "tonic 0.9.2",
+ "tonic",
  "tower",
 ]
 
@@ -736,7 +727,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tonic 0.9.2",
+ "tonic",
  "tower",
 ]
 
@@ -808,6 +799,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "ibeji-adapter"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "core-protobuf-data-access",
+ "freyja-common",
+ "freyja-contracts",
+ "futures",
+ "log",
+ "proc-macros",
+ "serde",
+ "serde_json",
+ "service_discovery_proto",
+ "strum",
+ "strum_macros",
+ "tempfile",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tower",
+]
+
+[[package]]
 name = "idna"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -868,7 +882,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tonic 0.9.2",
+ "tonic",
  "tower",
 ]
 
@@ -1210,16 +1224,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
-dependencies = [
- "proc-macro2",
- "syn 2.0.31",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1246,17 +1250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
  "bytes",
- "prost-derive 0.11.9",
-]
-
-[[package]]
-name = "prost"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa8473a65b88506c106c28ae905ca4a2b83a2993640467a41bb3080627ddfd2c"
-dependencies = [
- "bytes",
- "prost-derive 0.12.0",
+ "prost-derive",
 ]
 
 [[package]]
@@ -1272,33 +1266,11 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prettyplease 0.1.25",
- "prost 0.11.9",
- "prost-types 0.11.9",
+ "prettyplease",
+ "prost",
+ "prost-types",
  "regex",
  "syn 1.0.109",
- "tempfile",
- "which",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d3e647e9eb04ddfef78dfee2d5b3fefdf94821c84b710a3d8ebc89ede8b164"
-dependencies = [
- "bytes",
- "heck",
- "itertools",
- "log",
- "multimap",
- "once_cell",
- "petgraph",
- "prettyplease 0.2.15",
- "prost 0.12.0",
- "prost-types 0.12.0",
- "regex",
- "syn 2.0.31",
  "tempfile",
  "which",
 ]
@@ -1317,34 +1289,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-derive"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56075c27b20ae524d00f247b8a4dc333e5784f889fe63099f8e626bc8d73486c"
-dependencies = [
- "anyhow",
- "itertools",
- "proc-macro2",
- "quote",
- "syn 2.0.31",
-]
-
-[[package]]
 name = "prost-types"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
- "prost 0.11.9",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cebe0a918c97f86c217b0f76fd754e966f8b9f41595095cf7d74cb4e59d730f6"
-dependencies = [
- "prost 0.12.0",
+ "prost",
 ]
 
 [[package]]
@@ -1515,12 +1465,12 @@ name = "samples-protobuf-data-access"
 version = "1.0.0"
 source = "git+https://github.com/eclipse-ibeji/ibeji?rev=370a4f5ae529239607a383f5260966959f55cf3f#370a4f5ae529239607a383f5260966959f55cf3f"
 dependencies = [
- "prost 0.11.9",
- "prost-types 0.11.9",
+ "prost",
+ "prost-types",
  "serde",
  "tokio",
- "tonic 0.9.2",
- "tonic-build 0.9.2",
+ "tonic",
+ "tonic-build",
 ]
 
 [[package]]
@@ -1612,6 +1562,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "service_discovery_proto"
+version = "0.1.0"
+source = "git+https://github.com/eclipse-chariott/chariott#1a806fca4f9d40ed64f6b57a36c506e16f5f27d6"
+dependencies = [
+ "prost",
+ "tokio",
+ "tonic",
+ "tonic-build",
 ]
 
 [[package]]
@@ -1856,34 +1817,7 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost 0.11.9",
- "tokio",
- "tokio-stream",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5469afaf78a11265c343a88969045c1568aa8ecc6c787dbf756e92e70f199861"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum",
- "base64",
- "bytes",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-timeout",
- "percent-encoding",
- "pin-project",
- "prost 0.12.0",
+ "prost",
  "tokio",
  "tokio-stream",
  "tower",
@@ -1898,24 +1832,11 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6fdaae4c2c638bb70fe42803a26fbd6fc6ac8c72f5c59f67ecc2a2dcabf4b07"
 dependencies = [
- "prettyplease 0.1.25",
+ "prettyplease",
  "proc-macro2",
- "prost-build 0.11.9",
+ "prost-build",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "tonic-build"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b477abbe1d18c0b08f56cd01d1bc288668c5b5cfd19b2ae1886bbf599c546f1"
-dependencies = [
- "prettyplease 0.2.15",
- "proc-macro2",
- "prost-build 0.12.0",
- "quote",
- "syn 2.0.31",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,9 +587,9 @@ dependencies = [
 name = "freyja-e2e-app"
 version = "0.1.0"
 dependencies = [
+ "azure-cloud-connector-adapter",
  "freyja",
  "ibeji-adapter",
- "in-memory-mock-cloud-adapter",
  "in-memory-mock-mapping-client",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,6 +495,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "freyja-e2e-app"
+version = "0.1.0"
+dependencies = [
+ "freyja",
+ "in-memory-mock-cloud-adapter",
+ "in-memory-mock-digital-twin-adapter",
+ "in-memory-mock-mapping-client",
+ "tokio",
+]
+
+[[package]]
 name = "freyja-in-memory-app"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "freyja_adapters/cloud/azure_cloud_connector_adapter",
     "freyja_adapters/digital_twin/ibeji_adapter",
     "freyja_apps/in_memory",
+    "freyja_apps/e2e",
 ]
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "cloud_connectors/azure/mqtt_connector",
     "cloud_connectors/azure/proto-build",
     "freyja_adapters/cloud/azure_cloud_connector_adapter",
+    "freyja_adapters/digital_twin/ibeji_adapter",
     "freyja_apps/in_memory",
 ]
 
@@ -18,6 +19,7 @@ azure-cloud-connector-proto = { path = "cloud_connectors/azure/proto-build" }
 
 # ESDV dependencies
 # Versioning is managed by the Cargo.lock file rather than copying rev properties to all of these
+core-protobuf-data-access = { git = "https://github.com/eclipse-ibeji/ibeji" }
 freyja = { git = "https://github.com/eclipse-ibeji/freyja" }
 freyja-common = { git = "https://github.com/eclipse-ibeji/freyja" }
 freyja-contracts = { git = "https://github.com/eclipse-ibeji/freyja" }
@@ -25,6 +27,7 @@ in-memory-mock-cloud-adapter = { git = "https://github.com/eclipse-ibeji/freyja"
 in-memory-mock-digital-twin-adapter = { git = "https://github.com/eclipse-ibeji/freyja" }
 in-memory-mock-mapping-client = { git = "https://github.com/eclipse-ibeji/freyja" }
 proc-macros = { git = "https://github.com/eclipse-ibeji/freyja" }
+service_discovery_proto = { git = "https://github.com/eclipse-chariott/chariott" }
 
 # Cargo dependencies
 async-trait = "0.1.73"
@@ -32,13 +35,15 @@ env_logger = "0.10.0"
 futures = "0.3.28"
 log = "0.4.20"
 paho-mqtt = "0.12.1"
-prost = "0.12.0"
+prost = "0.11.0"
 serde = "1.0.188"
 serde_json = "1.0.106"
+strum = "0.25.0"
+strum_macros = "0.25.2"
 tempfile = "3.8.0"
 time = "0.3.28"
 tokio = "1.32.0"
 tokio-stream = "0.1.14"
-tonic = "0.10.0"
-tonic-build = "0.10.0"
+tonic = "0.9"
+tonic-build = "0.9"
 tower = "0.4.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,9 @@ members = [
 
 [workspace.dependencies]
 # Local dependencies
+azure-cloud-connector-adapter = { path = "freyja_adapters/cloud/azure_cloud_connector_adapter" }
 azure-cloud-connector-proto = { path = "cloud_connectors/azure/proto-build" }
+ibeji-adapter = { path = "freyja_adapters/digital_twin/ibeji_adapter" }
 
 # ESDV dependencies
 # Versioning is managed by the Cargo.lock file rather than copying rev properties to all of these

--- a/cloud_connectors/azure/mqtt_connector/src/mqtt_connector.rs
+++ b/cloud_connectors/azure/mqtt_connector/src/mqtt_connector.rs
@@ -14,7 +14,7 @@ use azure_cloud_connector_proto::azure_cloud_connector::azure_cloud_connector_se
 use azure_cloud_connector_proto::azure_cloud_connector::{
     UpdateDigitalTwinRequest, UpdateDigitalTwinResponse,
 };
-use freyja_common::utils::execute_with_retry;
+use freyja_common::retry_utils::execute_with_retry;
 
 /// Implementation of the MQTTConnector gRPC trait
 pub struct MQTTConnector {

--- a/freyja_adapters/cloud/azure_cloud_connector_adapter/src/azure_cloud_connector_adapter.rs
+++ b/freyja_adapters/cloud/azure_cloud_connector_adapter/src/azure_cloud_connector_adapter.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use tonic::transport::Channel;
 
 use crate::azure_cloud_connector_adapter_config::{Config, CONFIG_FILE};
-use freyja_common::utils::execute_with_retry;
+use freyja_common::retry_utils::execute_with_retry;
 use freyja_contracts::cloud_adapter::{
     CloudAdapter, CloudAdapterError, CloudMessageRequest, CloudMessageResponse,
 };

--- a/freyja_adapters/digital_twin/ibeji_adapter/Cargo.toml
+++ b/freyja_adapters/digital_twin/ibeji_adapter/Cargo.toml
@@ -1,0 +1,28 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+# SPDX-License-Identifier: MIT
+
+[package]
+name = "ibeji-adapter"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+
+[dependencies]
+async-trait = { workspace = true }
+core-protobuf-data-access  = { workspace = true }
+freyja-common = { workspace = true }
+freyja-contracts = { workspace = true }
+futures = { workspace = true }
+log = { workspace = true }
+proc-macros = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+service_discovery_proto = { workspace = true }
+strum = { workspace = true }
+strum_macros = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true }
+tokio-stream = { workspace = true, features = ["net"] }
+tonic = { workspace = true }
+tower = { workspace = true }

--- a/freyja_adapters/digital_twin/ibeji_adapter/README.md
+++ b/freyja_adapters/digital_twin/ibeji_adapter/README.md
@@ -1,0 +1,32 @@
+# Ibeji Adapter
+
+The Ibeji Adapter is used to integrate with the [Ibeji In-Vehicle Digital Twin Service](https://github.com/eclipse-ibeji/ibeji), and optionally [Chariott](https://github.com/eclipse-chariott/chariott) to discover Ibeji.
+
+## Configuration
+
+The `res` directory contains two sample config files. The `ibeji_adapter_config.sample.json` will be copied to the build output, so you can edit this file to configure the adapter.
+
+### Common Configuration Fields
+
+Whether or not you are using Chariott, the following config values are required:
+
+- `service_type`: Specifies whether to call Ibeji directly or use Chariott's Service Discovery system to find it. Valid values are `"ChariottDiscoveryService"` and `"InVehicleDigitalTwinService"`.
+- `uri`: The URI for the selected service.
+- `max_retries`: The maximum number of times to retry failed attempts to communicate with the digital twin service.
+- `retry_interval_ms`: The duration between retries.
+
+
+### Ibeji Without Chariott
+
+To use Ibeji without Chariott, the `service_type` must be `"InVehicleDigitalTwinService"`. No additional configuration is needed to use Ibeji without Chariott.
+
+### Ibeji With Chariott
+
+To use Ibeji with [Chariott's Service Discovery system](https://github.com/eclipse-chariott/chariott/blob/main/service_discovery/README.md), the `service_type` must be `"ChariottDiscoveryService"` and you must specify the following additional config for the adapter:
+
+- `metadata`: Information used to query Chariott's Service Discovery system. This is an object with the following properties:
+  - `namespace`: The service namespace for Ibeji.
+  - `name`: The service name for Ibeji.
+  - `version`: The service version for Ibeji.
+
+Ibeji must also be configured to use Chariott.

--- a/freyja_adapters/digital_twin/ibeji_adapter/README.md
+++ b/freyja_adapters/digital_twin/ibeji_adapter/README.md
@@ -15,7 +15,6 @@ Whether or not you are using Chariott, the following config values are required:
 - `max_retries`: The maximum number of times to retry failed attempts to communicate with the digital twin service.
 - `retry_interval_ms`: The duration between retries.
 
-
 ### Ibeji Without Chariott
 
 To use Ibeji without Chariott, the `service_type` must be `"InVehicleDigitalTwinService"`. No additional configuration is needed to use Ibeji without Chariott.
@@ -29,4 +28,4 @@ To use Ibeji with [Chariott's Service Discovery system](https://github.com/eclip
   - `name`: The service name for Ibeji.
   - `version`: The service version for Ibeji.
 
-Ibeji must also be configured to use Chariott.
+Ibeji must also be configured to use Chariott to use this feature.

--- a/freyja_adapters/digital_twin/ibeji_adapter/README.md
+++ b/freyja_adapters/digital_twin/ibeji_adapter/README.md
@@ -13,7 +13,7 @@ Whether or not you are using Chariott, the following config values are required:
 - `service_type`: Specifies whether to call Ibeji directly or use Chariott's Service Discovery system to find it. Valid values are `"ChariottDiscoveryService"` and `"InVehicleDigitalTwinService"`.
 - `uri`: The URI for the selected service.
 - `max_retries`: The maximum number of times to retry failed attempts to communicate with the digital twin service.
-- `retry_interval_ms`: The duration between retries.
+- `retry_interval_ms`: The duration between retries in milliseconds.
 
 ### Ibeji Without Chariott
 

--- a/freyja_adapters/digital_twin/ibeji_adapter/build.rs
+++ b/freyja_adapters/digital_twin/ibeji_adapter/build.rs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+use std::{env, fs, path::Path};
+
+const OUT_DIR: &str = "OUT_DIR";
+const SAMPLE_CONFIG_FILE: &str = "res/ibeji_adapter_config.sample.json";
+const CONFIG_FILE: &str = "ibeji_adapter_config.json";
+
+fn main() {
+    // The current directory of the build script is the package's root directory
+    let config_path = env::current_dir().unwrap().join(SAMPLE_CONFIG_FILE);
+
+    let target_dir = env::var(OUT_DIR).unwrap();
+    let dest_path = Path::new(&target_dir).join(CONFIG_FILE);
+
+    fs::copy(&config_path, dest_path).unwrap();
+
+    println!(
+        "The config ibeji_adapter_config.json is located in the {} directory",
+        target_dir
+    );
+    println!("cargo:rerun-if-changed={}", config_path.to_str().unwrap());
+}

--- a/freyja_adapters/digital_twin/ibeji_adapter/res/ibeji_adapter_config.sample.json
+++ b/freyja_adapters/digital_twin/ibeji_adapter/res/ibeji_adapter_config.sample.json
@@ -1,0 +1,6 @@
+{
+    "service_type": "InVehicleDigitalTwinService",
+    "uri": "http://[::1]:50001",
+    "max_retries": 5,
+    "retry_interval_ms": 1000
+}

--- a/freyja_adapters/digital_twin/ibeji_adapter/res/ibeji_adapter_config.sample.json
+++ b/freyja_adapters/digital_twin/ibeji_adapter/res/ibeji_adapter_config.sample.json
@@ -1,6 +1,6 @@
 {
     "service_type": "InVehicleDigitalTwinService",
-    "uri": "http://[::1]:50001",
+    "uri": "http://0.0.0.0:5010",
     "max_retries": 5,
     "retry_interval_ms": 1000
 }

--- a/freyja_adapters/digital_twin/ibeji_adapter/res/ibeji_adapter_config_with_chariott.sample.json
+++ b/freyja_adapters/digital_twin/ibeji_adapter/res/ibeji_adapter_config_with_chariott.sample.json
@@ -1,0 +1,11 @@
+{
+    "service_type": "ChariottDiscoveryService",
+    "uri": "http://0.0.0.0:50000",
+    "max_retries": 5,
+    "retry_interval_ms": 1000,
+    "metadata": {
+        "namespace": "sdv.ibeji",
+        "name": "invehicle_digital_twin",
+        "version": "1.0"
+    }
+}

--- a/freyja_adapters/digital_twin/ibeji_adapter/src/config.rs
+++ b/freyja_adapters/digital_twin/ibeji_adapter/src/config.rs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+use serde::{Deserialize, Serialize};
+
+pub(crate) const CONFIG_FILE: &str = "ibeji_adapter_config.json";
+
+/// Configuration setting variants for selecting the service
+/// that the Ibeji Adapter should communicate with to interact with Ibeji
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(tag = "service_type")]
+pub enum Settings {
+    /// In-Vehicle Digital Twin Service
+    InVehicleDigitalTwinService {
+        uri: String,
+        max_retries: u32,
+        retry_interval_ms: u64,
+    },
+
+    /// Chariott's Service Discovery to discover Ibeji
+    ChariottDiscoveryService {
+        uri: String,
+        max_retries: u32,
+        retry_interval_ms: u64,
+        metadata: IbejiDiscoveryMetadata,
+    },
+}
+
+/// Configuration metadata for discovering Ibeji using Chariott
+#[derive(Clone, Serialize, Deserialize)]
+pub struct IbejiDiscoveryMetadata {
+    pub namespace: String,
+    pub name: String,
+    pub version: String,
+}

--- a/freyja_adapters/digital_twin/ibeji_adapter/src/ibeji_adapter.rs
+++ b/freyja_adapters/digital_twin/ibeji_adapter/src/ibeji_adapter.rs
@@ -14,7 +14,7 @@ use service_discovery_proto::service_registry::v1::DiscoverRequest;
 use tonic::{transport::Channel, Request};
 
 use crate::config::{IbejiDiscoveryMetadata, Settings, CONFIG_FILE};
-use freyja_common::utils::execute_with_retry;
+use freyja_common::retry_utils::execute_with_retry;
 use freyja_contracts::{
     digital_twin_adapter::{
         DigitalTwinAdapter, DigitalTwinAdapterError, GetDigitalTwinProviderRequest,

--- a/freyja_adapters/digital_twin/ibeji_adapter/src/ibeji_adapter.rs
+++ b/freyja_adapters/digital_twin/ibeji_adapter/src/ibeji_adapter.rs
@@ -1,0 +1,345 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+use std::{fs, path::Path, str::FromStr, time::Duration};
+
+use async_trait::async_trait;
+use core_protobuf_data_access::invehicle_digital_twin::v1::{
+    invehicle_digital_twin_client::InvehicleDigitalTwinClient, EndpointInfo, FindByIdRequest,
+};
+use log::{info, warn};
+use service_discovery_proto::service_registry::v1::service_registry_client::ServiceRegistryClient;
+use service_discovery_proto::service_registry::v1::DiscoverRequest;
+use tonic::{transport::Channel, Request};
+
+use crate::config::{IbejiDiscoveryMetadata, Settings, CONFIG_FILE};
+use freyja_common::utils::execute_with_retry;
+use freyja_contracts::{
+    digital_twin_adapter::{
+        DigitalTwinAdapter, DigitalTwinAdapterError, GetDigitalTwinProviderRequest,
+        GetDigitalTwinProviderResponse,
+    },
+    entity::Entity,
+    provider_proxy::OperationKind,
+};
+
+const GET_OPERATION: &str = "Get";
+const SUBSCRIBE_OPERATION: &str = "Subscribe";
+
+/// Contacts the In-Vehicle Digital Twin Service in Ibeji
+pub struct IbejiAdapter {
+    client: InvehicleDigitalTwinClient<Channel>,
+}
+
+impl IbejiAdapter {
+    /// Retrieves Ibeji's In-Vehicle Digital Twin URI from Chariott
+    ///
+    /// # Arguments
+    /// - `chariott_service_discovery_uri`: the uri for Chariott's service discovery
+    /// - `metadata`: optional configuration metadata for discovering Ibeji using Chariott
+    async fn retrieve_ibeji_invehicle_digital_twin_uri_from_chariott(
+        chariott_service_discovery_uri: &str,
+        chariott_ibeji_config: IbejiDiscoveryMetadata,
+    ) -> Result<String, DigitalTwinAdapterError> {
+        let mut service_registry_client =
+            ServiceRegistryClient::connect(String::from(chariott_service_discovery_uri))
+                .await
+                .map_err(DigitalTwinAdapterError::communication)?;
+
+        let discover_request = Request::new(DiscoverRequest {
+            namespace: chariott_ibeji_config.namespace,
+            name: chariott_ibeji_config.name,
+            version: chariott_ibeji_config.version,
+        });
+
+        let service = service_registry_client
+            .discover(discover_request)
+            .await
+            .map_err(DigitalTwinAdapterError::communication)?
+            .into_inner()
+            .service
+            .ok_or_else(|| {
+                DigitalTwinAdapterError::communication(
+                    "Cannot discover the uri of Ibeji's In-Vehicle Digital Twin Service",
+                )
+            })?;
+
+        Ok(service.uri)
+    }
+}
+
+#[async_trait]
+impl DigitalTwinAdapter for IbejiAdapter {
+    /// Creates a new instance of a DigitalTwinAdapter with default settings
+    fn create_new() -> Result<Self, DigitalTwinAdapterError> {
+        let settings_content =
+            fs::read_to_string(Path::new(env!("OUT_DIR")).join(CONFIG_FILE)).unwrap();
+        let settings: Settings = serde_json::from_str(settings_content.as_str()).unwrap();
+
+        let (invehicle_digital_twin_service_uri, max_retries, retry_interval_ms) = match settings {
+            Settings::InVehicleDigitalTwinService {
+                uri,
+                max_retries,
+                retry_interval_ms,
+            } => (uri, max_retries, retry_interval_ms),
+            Settings::ChariottDiscoveryService {
+                uri,
+                max_retries,
+                retry_interval_ms,
+                metadata,
+            } => {
+                let invehicle_digital_twin_service_uri = futures::executor::block_on(async {
+                    execute_with_retry(
+                        max_retries,
+                        Duration::from_millis(retry_interval_ms),
+                        || {
+                            Self::retrieve_ibeji_invehicle_digital_twin_uri_from_chariott(
+                                &uri,
+                                metadata.clone(),
+                            )
+                        },
+                        Some(String::from("Connection retry for connecting to Chariott")),
+                    )
+                    .await
+                })
+                .unwrap();
+                info!("Discovered the uri of the In-Vehicle Digital Twin Service via Chariott: {invehicle_digital_twin_service_uri}");
+
+                (
+                    invehicle_digital_twin_service_uri,
+                    max_retries,
+                    retry_interval_ms,
+                )
+            }
+        };
+
+        let client = futures::executor::block_on(async {
+            execute_with_retry(
+                max_retries,
+                Duration::from_millis(retry_interval_ms),
+                || InvehicleDigitalTwinClient::connect(invehicle_digital_twin_service_uri.clone()),
+                Some(String::from("Connection retry for connecting to Ibeji")),
+            )
+            .await
+            .map_err(DigitalTwinAdapterError::communication)
+        })
+        .unwrap();
+
+        Ok(Self { client })
+    }
+
+    /// Gets entity access information
+    ///
+    /// # Arguments
+    /// - `request`: the request for finding an entity's access information
+    async fn find_by_id(
+        &self,
+        request: GetDigitalTwinProviderRequest,
+    ) -> Result<GetDigitalTwinProviderResponse, DigitalTwinAdapterError> {
+        let entity_id = request.entity_id;
+        let request = tonic::Request::new(FindByIdRequest {
+            id: entity_id.clone(),
+        });
+
+        let response = self
+            .client
+            .clone()
+            .find_by_id(request)
+            .await
+            .map_err(DigitalTwinAdapterError::entity_not_found)?;
+
+        // Extract the response from find_by_id
+        let entity_access_info = response
+            .into_inner()
+            .entity_access_info
+            .ok_or(format!("Cannot find {entity_id} with find_by_id"))
+            .map_err(DigitalTwinAdapterError::entity_not_found)?;
+        let entity_endpoint_info_list = entity_access_info.endpoint_info_list;
+
+        let endpoint: Option<(EndpointInfo, String)> = entity_endpoint_info_list
+            .into_iter()
+            .find_map(|endpoint_info| {
+                endpoint_info.operations.iter().find_map(|operation| {
+                    if *operation == SUBSCRIBE_OPERATION || *operation == GET_OPERATION {
+                        return Some((endpoint_info.clone(), operation.clone()));
+                    }
+                    None
+                })
+            });
+
+        if endpoint.is_none() {
+            let message = format!("No access info to connect with {entity_id}");
+            warn!("{message}");
+            return Err(DigitalTwinAdapterError::communication(message));
+        }
+
+        let (endpoint, _) = endpoint.unwrap();
+
+        // If both Subscribe and Get are supported, then we pick Subscribe over Get
+        let operation = if endpoint
+            .operations
+            .iter()
+            .any(|op| op == SUBSCRIBE_OPERATION)
+        {
+            String::from(SUBSCRIBE_OPERATION)
+        } else {
+            String::from(GET_OPERATION)
+        };
+
+        let operation =
+            OperationKind::from_str(&operation).map_err(DigitalTwinAdapterError::parse_error)?;
+        let entity = Entity {
+            id: entity_id,
+            description: Some(entity_access_info.description),
+            name: Some(entity_access_info.name),
+            operation,
+            uri: endpoint.uri,
+            protocol: endpoint.protocol,
+        };
+
+        Ok(GetDigitalTwinProviderResponse { entity })
+    }
+}
+
+#[cfg(test)]
+mod ibeji_digital_twin_adapter_tests {
+    use super::*;
+
+    use core_protobuf_data_access::invehicle_digital_twin::v1::{
+        invehicle_digital_twin_server::InvehicleDigitalTwin, EntityAccessInfo, FindByIdRequest,
+        FindByIdResponse, RegisterRequest, RegisterResponse,
+    };
+    use tonic::{Request, Response, Status};
+
+    const AMBIENT_AIR_TEMPERATURE_ID: &str = "dtmi:sdv:Vehicle:Cabin:HVAC:AmbientAirTemperature;1";
+
+    pub struct MockInVehicleTwin {}
+
+    #[tonic::async_trait]
+    impl InvehicleDigitalTwin for MockInVehicleTwin {
+        async fn find_by_id(
+            &self,
+            request: Request<FindByIdRequest>,
+        ) -> Result<Response<FindByIdResponse>, Status> {
+            let entity_id = request.into_inner().id;
+
+            if entity_id != AMBIENT_AIR_TEMPERATURE_ID {
+                return Err(Status::not_found(
+                    "Unable to find the entity with id {entity_id}",
+                ));
+            }
+            let endpoint_info = EndpointInfo {
+                protocol: String::from("grpc"),
+                uri: String::from("http://[::1]:40010"), // Devskim: ignore DS137138
+                context: String::from("dtmi:sdv:Vehicle:Cabin:HVAC:AmbientAirTemperature;1"),
+                operations: vec![String::from("Get"), String::from("Subscribe")],
+            };
+
+            let entity_access_info = EntityAccessInfo {
+                name: String::from("AmbientAirTemperature"),
+                id: String::from("dtmi:sdv:Vehicle:Cabin:HVAC:AmbientAirTemperature;1"),
+                description: String::from("Ambient air temperature"),
+                endpoint_info_list: vec![endpoint_info],
+            };
+
+            let response = FindByIdResponse {
+                entity_access_info: Some(entity_access_info),
+            };
+
+            Ok(Response::new(response))
+        }
+
+        async fn register(
+            &self,
+            _request: Request<RegisterRequest>,
+        ) -> Result<Response<RegisterResponse>, Status> {
+            let response = RegisterResponse {};
+            Ok(Response::new(response))
+        }
+    }
+
+    /// The tests below uses Unix sockets to create a channel between a gRPC client and a gRPC server.
+    /// Unix sockets are more ideal than using TCP/IP sockets since Rust tests will run in parallel
+    /// so you would need to set an arbitrary port per test for TCP/IP sockets.
+    #[cfg(unix)]
+    mod unix_tests {
+        use super::*;
+
+        use std::sync::Arc;
+
+        use core_protobuf_data_access::invehicle_digital_twin::v1::invehicle_digital_twin_server::InvehicleDigitalTwinServer;
+        use tempfile::TempPath;
+        use tokio::net::{UnixListener, UnixStream};
+        use tokio_stream::wrappers::UnixListenerStream;
+        use tonic::transport::{Channel, Endpoint, Server, Uri};
+        use tower::service_fn;
+
+        async fn create_test_grpc_client(
+            bind_path: Arc<TempPath>,
+        ) -> InvehicleDigitalTwinClient<Channel> {
+            let channel = Endpoint::try_from("http://URI_IGNORED") // Devskim: ignore DS137138
+                .unwrap()
+                .connect_with_connector(service_fn(move |_: Uri| {
+                    let bind_path = bind_path.clone();
+                    async move { UnixStream::connect(bind_path.as_ref()).await }
+                }))
+                .await
+                .unwrap();
+
+            InvehicleDigitalTwinClient::new(channel)
+        }
+
+        async fn run_test_grpc_server(uds_stream: UnixListenerStream) {
+            let mock_in_vehicle_twin = MockInVehicleTwin {};
+            Server::builder()
+                .add_service(InvehicleDigitalTwinServer::new(mock_in_vehicle_twin))
+                .serve_with_incoming(uds_stream)
+                .await
+                .unwrap();
+        }
+
+        #[tokio::test]
+        async fn find_by_id_test() {
+            // Create the Unix Socket
+            let bind_path = Arc::new(tempfile::NamedTempFile::new().unwrap().into_temp_path());
+            let uds = match UnixListener::bind(bind_path.as_ref()) {
+                Ok(unix_listener) => unix_listener,
+                Err(_) => {
+                    std::fs::remove_file(bind_path.as_ref()).unwrap();
+                    UnixListener::bind(bind_path.as_ref()).unwrap()
+                }
+            };
+            let uds_stream = UnixListenerStream::new(uds);
+
+            let request_future = async {
+                let client = create_test_grpc_client(bind_path.clone()).await;
+                let ibeji_digital_twin_adapter = IbejiAdapter { client };
+
+                let request = GetDigitalTwinProviderRequest {
+                    entity_id: String::from("invalid_entity"),
+                };
+
+                let result = ibeji_digital_twin_adapter.find_by_id(request).await;
+
+                assert!(result.is_err());
+
+                let request = GetDigitalTwinProviderRequest {
+                    entity_id: String::from(AMBIENT_AIR_TEMPERATURE_ID),
+                };
+                let result = ibeji_digital_twin_adapter.find_by_id(request).await;
+                assert!(result.is_ok());
+
+                let response = result.unwrap();
+                assert_eq!(response.entity.operation, OperationKind::Subscribe);
+            };
+
+            tokio::select! {
+                _ = run_test_grpc_server(uds_stream) => (),
+                _ = request_future => ()
+            }
+
+            std::fs::remove_file(bind_path.as_ref()).unwrap();
+        }
+    }
+}

--- a/freyja_adapters/digital_twin/ibeji_adapter/src/lib.rs
+++ b/freyja_adapters/digital_twin/ibeji_adapter/src/lib.rs
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+mod config;
+pub mod ibeji_adapter;

--- a/freyja_apps/e2e/Cargo.toml
+++ b/freyja_apps/e2e/Cargo.toml
@@ -16,5 +16,5 @@ tokio = { workspace = true, features = ["macros"] }
 # Put any dependencies that you need for your adapters down here.
 # This samples utilizes the in-memory mock adapters.
 in-memory-mock-cloud-adapter = { workspace = true }
-in-memory-mock-digital-twin-adapter = { workspace = true }
+ibeji-adapter = { workspace = true }
 in-memory-mock-mapping-client = { workspace = true }

--- a/freyja_apps/e2e/Cargo.toml
+++ b/freyja_apps/e2e/Cargo.toml
@@ -1,0 +1,20 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+# SPDX-License-Identifier: MIT
+
+[package]
+name = "freyja-in-memory-app"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+
+[dependencies]
+# These two dependencies are required for anyone implementing a Freyja application
+freyja = { workspace = true }
+tokio = { workspace = true, features = ["macros"] }
+
+# Put any dependencies that you need for your adapters down here.
+# This samples utilizes the in-memory mock adapters.
+in-memory-mock-cloud-adapter = { workspace = true }
+in-memory-mock-digital-twin-adapter = { workspace = true }
+in-memory-mock-mapping-client = { workspace = true }

--- a/freyja_apps/e2e/Cargo.toml
+++ b/freyja_apps/e2e/Cargo.toml
@@ -15,6 +15,6 @@ tokio = { workspace = true, features = ["macros"] }
 
 # Put any dependencies that you need for your adapters down here.
 # This samples utilizes the in-memory mock adapters.
-in-memory-mock-cloud-adapter = { workspace = true }
+azure-cloud-connector-adapter = { workspace = true }
 ibeji-adapter = { workspace = true }
 in-memory-mock-mapping-client = { workspace = true }

--- a/freyja_apps/e2e/Cargo.toml
+++ b/freyja_apps/e2e/Cargo.toml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 [package]
-name = "freyja-in-memory-app"
+name = "freyja-e2e-app"
 version = "0.1.0"
 edition = "2021"
 license = "MIT"

--- a/freyja_apps/e2e/README.md
+++ b/freyja_apps/e2e/README.md
@@ -1,0 +1,13 @@
+# End-To-End Freyja Example Application
+
+This Freyja Example Application utilizes the [Ibeji Digital Twin Adapter] and the [Azure Cloud Connector Adapter] to show a minimal end-to-end example of how to sync data from the vehicle to the cloud.
+
+## Build and Run
+
+To build and run the application, run the following from the repo root:
+
+```shell
+cargo run -p freyja-e2e-app
+```
+
+This will rebuild the application as necessary and then run it. Note that running Cargo commands without specifying the `-p` argument might target every package in the workspace! When working with this repository it's recommended to use the `-p` argument with Cargo commands.

--- a/freyja_apps/e2e/README.md
+++ b/freyja_apps/e2e/README.md
@@ -1,13 +1,21 @@
 # End-To-End Freyja Example Application
 
-This Freyja Example Application utilizes the [Ibeji Digital Twin Adapter] and the [Azure Cloud Connector Adapter] to show a minimal end-to-end example of how to sync data from the vehicle to the cloud.
+This Freyja Example Application utilizes the [Ibeji Digital Twin Adapter](../../freyja_adapters/digital_twin/ibeji_adapter/) and the [Azure Cloud Connector Adapter](../../freyja_adapters/cloud/azure_cloud_connector_adapter/) to show a minimal end-to-end example of how to sync data from the vehicle to the cloud.
 
 ## Build and Run
 
-To build and run the application, run the following from the repo root:
+To build and run the application, follow these steps:
 
-```shell
-cargo run -p freyja-e2e-app
-```
+1. (Optional) If necessary, author configuration overrides for the [`InMemoryMockMappingClient`](https://github.com/eclipse-ibeji/freyja/tree/main/mapping_clients/in_memory_mock_mapping_client). Refer to the adapter README files for instructions on how to do this. This repository provides overrides in the [`.freyja`](../../.freyja/) directory that can be used with the [`mixed` sample provided by Ibeji](https://github.com/eclipse-ibeji/ibeji/tree/main/samples/mixed).
 
-This will rebuild the application as necessary and then run it. Note that running Cargo commands without specifying the `-p` argument might target every package in the workspace! When working with this repository it's recommended to use the `-p` argument with Cargo commands.
+1. Set the `$FREYJA_HOME` environment variable. If you are using the provided overrides, you can run the following command to set the variable:
+
+        export FREYJA_HOME={path-to-repo-root}/.freyja
+
+    Alternatively, you can set the variable in a [Cargo configuration file](https://doc.rust-lang.org/cargo/reference/config.html) to only enable the variable while running a Cargo command.
+
+1. Run the following from the repo root:
+
+        cargo run -p freyja-e2e-app
+
+    This will rebuild the application as necessary and then run it. Note that running Cargo commands without specifying the `-p` argument might target every package in the workspace! When working with this repository it's recommended to use the `-p` argument with Cargo commands.

--- a/freyja_apps/e2e/src/main.rs
+++ b/freyja_apps/e2e/src/main.rs
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+use in_memory_mock_cloud_adapter::in_memory_mock_cloud_adapter::InMemoryMockCloudAdapter;
+use in_memory_mock_digital_twin_adapter::in_memory_mock_digital_twin_adapter::InMemoryMockDigitalTwinAdapter;
+use in_memory_mock_mapping_client::in_memory_mock_mapping_client::InMemoryMockMappingClient;
+
+freyja::freyja_main! {InMemoryMockDigitalTwinAdapter, InMemoryMockCloudAdapter, InMemoryMockMappingClient}

--- a/freyja_apps/e2e/src/main.rs
+++ b/freyja_apps/e2e/src/main.rs
@@ -3,11 +3,11 @@
 // SPDX-License-Identifier: MIT
 
 use ibeji_adapter::ibeji_adapter::IbejiAdapter;
-use in_memory_mock_cloud_adapter::in_memory_mock_cloud_adapter::InMemoryMockCloudAdapter;
+use azure_cloud_connector_adapter::azure_cloud_connector_adapter::AzureCloudConnectorAdapter;
 use in_memory_mock_mapping_client::in_memory_mock_mapping_client::InMemoryMockMappingClient;
 
 freyja::freyja_main! {
     IbejiAdapter,
-    InMemoryMockCloudAdapter,
+    AzureCloudConnectorAdapter,
     InMemoryMockMappingClient
 }

--- a/freyja_apps/e2e/src/main.rs
+++ b/freyja_apps/e2e/src/main.rs
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
 
-use ibeji_adapter::ibeji_adapter::IbejiAdapter;
 use azure_cloud_connector_adapter::azure_cloud_connector_adapter::AzureCloudConnectorAdapter;
+use ibeji_adapter::ibeji_adapter::IbejiAdapter;
 use in_memory_mock_mapping_client::in_memory_mock_mapping_client::InMemoryMockMappingClient;
 
 freyja::freyja_main! {

--- a/freyja_apps/e2e/src/main.rs
+++ b/freyja_apps/e2e/src/main.rs
@@ -2,8 +2,12 @@
 // Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
 
+use ibeji_adapter::ibeji_adapter::IbejiAdapter;
 use in_memory_mock_cloud_adapter::in_memory_mock_cloud_adapter::InMemoryMockCloudAdapter;
-use in_memory_mock_digital_twin_adapter::in_memory_mock_digital_twin_adapter::InMemoryMockDigitalTwinAdapter;
 use in_memory_mock_mapping_client::in_memory_mock_mapping_client::InMemoryMockMappingClient;
 
-freyja::freyja_main! {InMemoryMockDigitalTwinAdapter, InMemoryMockCloudAdapter, InMemoryMockMappingClient}
+freyja::freyja_main! {
+    IbejiAdapter,
+    InMemoryMockCloudAdapter,
+    InMemoryMockMappingClient
+}


### PR DESCRIPTION
Migrates the `IbejiAdapter` from the Freyja repo and makes updates as necessary