### PR TITLE
Add notice generation workflow, toolchain file, and missing readmes

### DIFF
--- a/.github/workflows/notice-generation.yml
+++ b/.github/workflows/notice-generation.yml
@@ -1,0 +1,30 @@
+name: Notice generation
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 0" # once a week, on sundays at midnight UTC
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  notice_generation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository and submodules
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Install toolchain
+        uses: ./.github/actions/install-rust-toolchain
+      - name: Cache Dependencies
+        uses: Swatinem/rust-cache@v1
+      - name: Generate the Notice
+        run: |
+          git config --global user.email "ibeji-bot@eclipse.org"
+          git config --global user.name "Automated Notice Generation Pipeline"
+          ./tools/notice_generation.sh
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN  }}

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Eclipse Foundation Community Code of Conduct
+
+This project has adopted the [Eclipse Foundation Community Code of Conduct](https://raw.githubusercontent.com/eclipse/.github/master/CODE_OF_CONDUCT.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing
+
+Welcome to the Ibeji community. Start here for info on how to contribute and help improve our project.
+
+## How to Contribute
+
+This project welcomes contributions and suggestions.
+
+You'll need to create an [Eclipse Foundation account](https://accounts.eclipse.org/) and agree to the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php). See more info at <https://www.eclipse.org/projects/handbook/#contributing-contributors>.
+
+If you have a bug to report or a feature to suggest, please use the New Issue button on the Issues page to access templates for these items.
+
+## Communication
+
+Please join our [developer mailing list](https://accounts.eclipse.org/mailing-list/ibeji-dev) for up to date information.
+
+## Code of Conduct
+
+This project has adopted the [Eclipse Foundation Community Code of Conduct](https://raw.githubusercontent.com/eclipse/.github/master/CODE_OF_CONDUCT.md).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"

--- a/tools/cg/about.hbs
+++ b/tools/cg/about.hbs
@@ -1,0 +1,31 @@
+# Third Party Licenses
+
+This page lists the licenses of the projects used in cargo-about.
+
+## Overview of licenses
+
+{{#each overview}}
+- {{{name}}} ({{count}})
+{{/each}}
+
+## All license text
+
+{{#each licenses}}
+### {{{id}}} ({{{name}}})
+
+#### Used by
+
+{{#each used_by}}
+- [{{{crate.name}}}]({{#if crate.repository}} {{crate.repository}} {{else}} https://crates.io/crates/{{crate.name}} {{/if}}) {{{crate.version}}}
+{{/each}}
+
+#### License
+
+```text
+{{{text}}}
+```
+
+{{/each}}
+## Disclaimer
+
+This NOTICE file has been generated with the usage of [cargo-about](https://github.com/EmbarkStudios/cargo-about), licensed under [MIT License](https://github.com/EmbarkStudios/cargo-about/blob/main/LICENSE-MIT)

--- a/tools/cg/about.toml
+++ b/tools/cg/about.toml
@@ -1,0 +1,11 @@
+accepted = [
+    "MIT",
+    "Apache-2.0",
+    "EPL-1.0",
+    "EPL-2.0",
+    "Unicode-DFS-2016",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "Zlib",
+    "CC0-1.0",
+]

--- a/tools/dotnet_append_to_notice.sh
+++ b/tools/dotnet_append_to_notice.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -e
+
+# Check if the correct number of arguments are provided
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 path_to_markdown_file path_to_json_file"
+    exit 1
+fi
+
+# Assign arguments to variables for clarity
+markdown_file="$1"
+json_file="$2"
+
+# Check if the markdown file exists
+if [ ! -f "$markdown_file" ]; then
+    echo "Error: markdown file '$markdown_file' not found"
+    exit 1
+fi
+
+# Check if the JSON file exists
+if [ ! -f "$json_file" ]; then
+    echo "Error: JSON file '$json_file' not found"
+    exit 1
+fi
+
+# Append header to markdown file
+echo -e "\n\n# .NET Third Party Licenses\nThe following lists the licenses of the .NET projects used.\n" >> "$markdown_file"
+
+# Read JSON file and append information to markdown file
+while read -r line; do
+    # Extract values from JSON object
+    license_type=$(echo "$line" | jq -r '.LicenseType')
+    package_name=$(echo "$line" | jq -r '.PackageName')
+    package_version=$(echo "$line" | jq -r '.PackageVersion')
+    package_url=$(echo "$line" | jq -r '.PackageUrl')
+    license_description=$(echo "$line" | jq -r '.LicenseDescription')
+
+    # Append information to markdown file in specified format
+    echo "### $license_type" >> "$markdown_file"
+    echo -e "\n#### Used by\n" >> "$markdown_file"
+    echo "- [$package_name]( $package_url ) $package_version" >> "$markdown_file"
+    echo -e "\n#### License\n" >> "$markdown_file"
+    echo '```text' >> "$markdown_file"
+    echo -e "$license_description" >> "$markdown_file"
+    echo '```' >> "$markdown_file"
+done < <(jq -c '.[]' "$json_file")
+
+echo -e "\n## Disclaimer" >> "$markdown_file"
+echo -e "
+This .NET Third Party Licenses list has been generated with [nuget-license](https://github.com/tomchavakis/nuget-license), \
+licensed under [Apache License 2.0](https://github.com/tomchavakis/nuget-license/blob/master/LICENSE)" >> "$markdown_file"
+
+exit 0

--- a/tools/dotnet_get_licenses.sh
+++ b/tools/dotnet_get_licenses.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -e
+
+# Check if the correct number of arguments are provided
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 path_to_json_file path_to_text_files_directory"
+    exit 1
+fi
+
+# Assign arguments to variables for clarity
+json_file="$1"
+text_files_dir="$2"
+
+# Check if the JSON file exists
+if [ ! -f "$json_file" ]; then
+    echo "Error: JSON file '$json_file' not found"
+    exit 1
+fi
+
+# Check if the text files directory exists
+if [ ! -d "$text_files_dir" ]; then
+    echo "Error: text files directory '$text_files_dir' not found"
+    exit 1
+fi
+
+# Create a temporary file to store the updated JSON
+temp_file=$(mktemp)
+
+# Read JSON file and update elements with LicenseDescription field
+while read -r line; do
+    # Extract values from JSON object
+    package_name=$(echo "$line" | jq -r '.PackageName')
+    package_version=$(echo "$line" | jq -r '.PackageVersion')
+
+    # Construct path to license description text file
+    license_description_file="${text_files_dir}/${package_name}_${package_version}.txt"
+
+    # Check if the license description text file exists
+    if [ ! -f "$license_description_file" ]; then
+        echo "Error: license description text file '$license_description_file' not found"
+        exit 1
+    fi
+
+    # Read license description text file and add LicenseDescription field to JSON object
+    license_description=$(cat "$license_description_file")
+    updated_json=$(echo "$line" | jq --arg desc "$license_description" '. + {LicenseDescription: $desc}')
+
+    # Write updated JSON object to temporary file
+    echo "$updated_json" >> "$temp_file"
+done < <(jq -c '.[]' "$json_file")
+
+# Overwrite original JSON file with updated JSON from temporary file
+jq -s '.' "$temp_file" > "$json_file"
+
+# Remove temporary file
+rm "$temp_file"
+
+exit 0

--- a/tools/dotnet_notice_generation.sh
+++ b/tools/dotnet_notice_generation.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+# SPDX-License-Identifier: MIT
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+# Check if the correct number of argments are passed
+if [ "$#" -lt 3 ] ; then
+    echo "Usage: $0 <PATH_TO_NOTICE_FILE> <CSHARP_PROJ_DIRECTORY> <PATH_TO_LICENSE_URL_TO_LICENSE_MAPPINGS>"
+    exit 1
+fi
+
+# Assign notice_file_path and dotnet_directory to arguments
+notice_file_path="$1"
+dotnet_directory="$2"
+license_url_to_license_mappings="$3"
+
+# Check if the notice file exists
+if [ ! -f "$notice_file_path" ]; then
+    echo "Error: Notice file '$notice_file_path' not found"
+    exit 1
+fi
+
+if ! dotnet tool list --global | grep -q 'dotnet-project-licenses'; then
+    dotnet tool install --global dotnet-project-licenses
+fi
+
+dotnet_licenses_output_directory="$dotnet_directory/dotnet_licenses_output"
+mkdir -p "$dotnet_licenses_output_directory"
+echo "Getting the .NET Third Party licenses"
+
+dotnet-project-licenses -i $dotnet_directory -o -f "$dotnet_licenses_output_directory" -u --json -e -c \
+    --licenseurl-to-license-mappings "$license_url_to_license_mappings"
+
+./tools/dotnet_get_licenses.sh "$dotnet_licenses_output_directory/licenses.json" "$dotnet_directory/dotnet_licenses_output"
+./tools/dotnet_append_to_notice.sh "$notice_file_path" "$dotnet_licenses_output_directory/licenses.json"
+
+rm -r "$dotnet_licenses_output_directory"
+
+exit 0

--- a/tools/notice_generation.sh
+++ b/tools/notice_generation.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+# SPDX-License-Identifier: MIT
+
+set -e
+cd "$(dirname "$0")/.."
+
+if ! command -v gh &> /dev/null
+then
+    echo "GitHub CLI not found. Please install before running the script."
+    exit
+fi
+
+if [ -z "$GITHUB_TOKEN" ]
+then
+      echo "Missing \$GITHUB_TOKEN environment variable. Please set it before running the script."
+      exit 1
+fi
+
+if ! command -v cargo-about &> /dev/null
+then
+    echo "Cargo-about could not be found. Installing now"
+    cargo install --locked cargo-about
+fi
+
+PR_TITLE="chore: Notice file change"
+if [ `gh pr list --search "$PR_TITLE" --json number | jq '. | length'` -gt 0 ]
+then
+    echo>&2 "A PR is already there for a NOTICE file change. Please merge it or cancel it to have this pipeline properly running."
+    exit 1
+fi
+
+NOTICE_FILENAME="NOTICE"
+echo "Running cargo-about for NOTICE file generation..."
+cargo about generate --workspace tools/cg/about.hbs --config tools/cg/about.toml > $NOTICE_FILENAME
+
+CLOUD_CONNECTORS_AZURE_DIRECTORY="cloud_connectors/azure/"
+echo "Appending Azure Cloud Connectors' .NET Third Party licenses to $NOTICE_FILENAME"
+./tools/dotnet_notice_generation.sh $NOTICE_FILENAME $CLOUD_CONNECTORS_AZURE_DIRECTORY ./tools/cg/license_url_to_type.json
+
+if [ -z "$(git diff --name-only $NOTICE_FILENAME)" ]
+then
+      echo "File not changed"
+else
+      echo "File changed. Checking out a new branch and creating a PR"
+      BRANCH_NAME="fix/notice-file-update-$(date +%s)"
+      git checkout -b "$BRANCH_NAME"
+      git add $NOTICE_FILENAME
+      git commit -m "New notice file"
+      git push -f --set-upstream origin "$BRANCH_NAME"
+      gh pr create -B main -H "$BRANCH_NAME" --title "$PR_TITLE" --body 'This PR is merging latest changes related to notice file. Please review them before approving.'
+fi


### PR DESCRIPTION
Adds the following:
- Notice generation workflow and associated files
- LICENSE
- CONTRIBUTING.md
- CODE_OF_CONDUCT.md
- rust-toolchain.toml

Contents were taken from the Freyja repo