### PR TITLE
Add script for deploying a digital twin that matches the smart trailer use case

### DIFF
--- a/cloud_connectors/azure/README.md
+++ b/cloud_connectors/azure/README.md
@@ -34,7 +34,7 @@ You must install the following:
 
 ### Azure Resource Group Role-Based Access Control
 
-You will need to be an Owner or a Contributor for your Azure resource group to deploy Azure resources using the scripts. Please see [Azure built-in roles](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles) for more details.
+You will need to be an Owner for your Azure resource group to deploy Azure resources using the scripts. Please see [Azure built-in roles](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles) for more details.
 
 ## Automated Deployment of Azure Resources
 

--- a/cloud_connectors/azure/digital_twins_connector/README.md
+++ b/cloud_connectors/azure/digital_twins_connector/README.md
@@ -20,7 +20,7 @@ sudo apt install dotnet-sdk-6.0
 
 ### Automated Azure Digital Twins Setup
 
-Before starting this section, please view [Prerequisites for Automated Deployment of Azure Resources](../README.md#prerequisites-for-automated-deployment-of-azure-resources).
+Before starting this section, please read [Prerequisites for Automated Deployment of Azure Resources](../README.md#prerequisites-for-automated-deployment-of-azure-resources).
 
 1. Sign in with Azure CLI. Follow the prompts after entering the following command.
 
@@ -33,12 +33,12 @@ az login --use-device-code
 ```shell
 cd {freyja-root-dir}/cloud_connectors/azure/scripts
 chmod +x digital_twins_setup.sh
-./digital_twins_setup.sh -r myRG -l westus2 -d myADT
+./digital_twins_setup.sh -r {myRG} -l westus2 -d {myADT}
 ```
 
 ### Automated Azure Digital Twins Setup for Smart Trailer Example
 
-Before starting this section, please view [Prerequisites for Automated Deployment of Azure Resources](../README.md#prerequisites-for-automated-deployment-of-azure-resources).
+Before starting this section, please read [Prerequisites for Automated Deployment of Azure Resources](../README.md#prerequisites-for-automated-deployment-of-azure-resources).
 
 1. Sign in with Azure CLI. Follow the prompts after entering the following command.
 
@@ -51,7 +51,7 @@ az login --use-device-code
 ```shell
 cd {freyja-root-dir}/cloud_connectors/azure/scripts
 chmod +x digital_twins_setup_smart_trailer.sh
-./digital_twins_setup.sh -r myRG -l westus2 -d myADT
+./digital_twins_setup.sh -r {myRG} -l westus2 -d {myADT}
 ```
 
 ### Manual Azure Digital Twins Setup

--- a/cloud_connectors/azure/digital_twins_connector/README.md
+++ b/cloud_connectors/azure/digital_twins_connector/README.md
@@ -36,6 +36,24 @@ chmod +x digital_twins_setup.sh
 ./digital_twins_setup.sh -r myRG -l westus2 -d myADT
 ```
 
+### Automated Azure Digital Twins Setup for Smart Trailer Example
+
+Before starting this section, please view [Prerequisites for Automated Deployment of Azure Resources](../README.md#prerequisites-for-automated-deployment-of-azure-resources).
+
+1. Sign in with Azure CLI. Follow the prompts after entering the following command.
+
+```shell
+az login --use-device-code
+```
+
+1. Deploy Azure Digital Twins to your resource group.
+
+```shell
+cd {freyja-root-dir}/cloud_connectors/azure/scripts
+chmod +x digital_twins_setup_smart_trailer.sh
+./digital_twins_setup.sh -r myRG -l westus2 -d myADT
+```
+
 ### Manual Azure Digital Twins Setup
 
 If you have successfully ran the `digital_twins_setup.sh`, you do not need to follow this section.

--- a/cloud_connectors/azure/sample-dtdl/trailer.json
+++ b/cloud_connectors/azure/sample-dtdl/trailer.json
@@ -1,0 +1,17 @@
+{
+    "@context": [
+        "dtmi:dtdl:context;2"
+    ],
+    "@type": "Interface",
+    "@id": "dtmi:sdv:Cloud:Trailer;1",
+    "description": "Trailer used for transporting cargo",
+    "contents": [
+        {
+            "@type": "Property",
+            "@id": "dtmi:sdv:Cloud:Trailer:Weight;1",
+            "name": "Weight",
+            "description": "The weight of the trailer",
+            "schema": "integer"
+        }
+    ]
+}

--- a/cloud_connectors/azure/scripts/digital_twins_setup.sh
+++ b/cloud_connectors/azure/scripts/digital_twins_setup.sh
@@ -15,33 +15,33 @@ usage() {
 # Parse command line arguments
 while [[ $# -gt 0 ]]
 do
-key="$1"
+    key="$1"
 
-case $key in
-    -r|--resource-group-name)
-    resource_group="$2"
-    shift # past argument
-    shift # past value
-    ;;
-    -l|--location)
-    location="$2"
-    shift # past argument
-    shift # past value
-    ;;
-    -d|--digital-twins-name)
-    digital_twin_name="$2"
-    shift # past argument
-    shift # past value
-    ;;
-    -h|--help)
-    usage
-    exit 0
-    ;;
-    *)
-    echo "Unknown argument: $key"
-    usage
-    exit 1
-esac
+    case $key in
+        -r|--resource-group-name)
+            resource_group="$2"
+            shift # past argument
+            shift # past value
+            ;;
+        -l|--location)
+            location="$2"
+            shift # past argument
+            shift # past value
+            ;;
+        -d|--digital-twins-name)
+            digital_twin_name="$2"
+            shift # past argument
+            shift # past value
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $key"
+            usage
+            exit 1
+    esac
 done
 
 # Check if all required arguments have been set
@@ -65,8 +65,8 @@ fi
 
 # Assign the Digital Twins Data Owner role
 echo -e "\nAssigning the Azure Digital Twins Data Owner role"
-userObjectID=$(az ad signed-in-user show --query id -o tsv)
-az dt role-assignment create --dt-name "$digital_twin_name" --assignee "$userObjectID"  --role "Azure Digital Twins Data Owner"
+user_object_id=$(az ad signed-in-user show --query id -o tsv)
+az dt role-assignment create --dt-name "$digital_twin_name" --assignee "$user_object_id"  --role "Azure Digital Twins Data Owner"
 
 # Upload the sample-dtdl models
 echo -e "\nUploading sample-dtdl models"

--- a/cloud_connectors/azure/scripts/digital_twins_setup_smart_trailer.sh
+++ b/cloud_connectors/azure/scripts/digital_twins_setup_smart_trailer.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+# SPDX-License-Identifier: MIT
+
+set -e
+
+# Set the current directory to where the script lives.
+cd "$(dirname "$0")"
+
+# Function to display usage information
+usage() {
+    echo "Usage: $0 [-r|--resource-group-name] <RESOURCE_GROUP_NAME> [-l|--location] <DEPLOYMENT_LOCATION> [-d|--digital-twins-name] <DIGITAL_TWINS_NAME>"
+    echo "Example:"
+    echo "  $0 -r myRG -l westus2 -d myADT"
+}
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+    -r|--resource-group-name)
+    resource_group="$2"
+    shift # past argument
+    shift # past value
+    ;;
+    -l|--location)
+    location="$2"
+    shift # past argument
+    shift # past value
+    ;;
+    -d|--digital-twins-name)
+    digital_twin_name="$2"
+    shift # past argument
+    shift # past value
+    ;;
+    -h|--help)
+    usage
+    exit 0
+    ;;
+    *)
+    echo "Unknown argument: $key"
+    usage
+    exit 1
+esac
+done
+
+# Check if all required arguments have been set
+if [[ -z "${resource_group}" || -z "${location}" || -z "${digital_twin_name}" ]]; then
+    echo "Error: Missing required arguments:"
+    [[ -z "${resource_group}" ]] && echo "  -r|--resource-group-name"
+    [[ -z "${location}" ]] && echo "  -l|--location"
+    [[ -z "${digital_twin_name}" ]] && echo "  -d|--digital-twins-name"
+    echo -e "\n"
+    usage
+    exit 1
+fi
+
+# Check if the Digital Twins instance exists
+if az dt show -n "$digital_twin_name" > /dev/null 2>&1; then
+    echo "Digital Twins instance '$digital_twin_name' already exists in resource group '$resource_group'"
+else
+    echo -e "\nCreating the Azure Digital Twins resource"
+    az dt create --dt-name "$digital_twin_name" --resource-group "$resource_group" --location "$location"
+fi
+
+# Assign the Digital Twins Data Owner role
+echo -e "\nAssigning the Azure Digital Twins Data Owner role"
+userObjectID=$(az ad signed-in-user show --query id -o tsv)
+az dt role-assignment create --dt-name "$digital_twin_name" --assignee "$userObjectID"  --role "Azure Digital Twins Data Owner"
+
+# Upload the sample-dtdl models
+echo -e "\nUploading sample-dtdl models"
+for file in $(find ../sample-dtdl -name "trailer.json"); do
+    if ! az dt model create --dt-name ${digital_twin_name} --models $file; then
+        echo "$file" dtdl already uploaded.
+    fi
+done
+
+# Create the Azure Digital Twin instances
+echo -e "\nCreating the Azure Digital Twin instances"
+az dt twin create --dt-name "$digital_twin_name" --dtmi "dtmi:sdv:Cloud:Trailer;1" --twin-id trailer
+
+echo -e "\nSetup finished for Freyja's Sample Azure Digital Twins"
+exit 0

--- a/cloud_connectors/azure/scripts/digital_twins_setup_smart_trailer.sh
+++ b/cloud_connectors/azure/scripts/digital_twins_setup_smart_trailer.sh
@@ -19,33 +19,33 @@ usage() {
 # Parse command line arguments
 while [[ $# -gt 0 ]]
 do
-key="$1"
+    key="$1"
 
-case $key in
-    -r|--resource-group-name)
-    resource_group="$2"
-    shift # past argument
-    shift # past value
-    ;;
-    -l|--location)
-    location="$2"
-    shift # past argument
-    shift # past value
-    ;;
-    -d|--digital-twins-name)
-    digital_twin_name="$2"
-    shift # past argument
-    shift # past value
-    ;;
-    -h|--help)
-    usage
-    exit 0
-    ;;
-    *)
-    echo "Unknown argument: $key"
-    usage
-    exit 1
-esac
+    case $key in
+        -r|--resource-group-name)
+            resource_group="$2"
+            shift # past argument
+            shift # past value
+            ;;
+        -l|--location)
+            location="$2"
+            shift # past argument
+            shift # past value
+            ;;
+        -d|--digital-twins-name)
+            digital_twin_name="$2"
+            shift # past argument
+            shift # past value
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $key"
+            usage
+            exit 1
+    esac
 done
 
 # Check if all required arguments have been set
@@ -69,8 +69,8 @@ fi
 
 # Assign the Digital Twins Data Owner role
 echo -e "\nAssigning the Azure Digital Twins Data Owner role"
-userObjectID=$(az ad signed-in-user show --query id -o tsv)
-az dt role-assignment create --dt-name "$digital_twin_name" --assignee "$userObjectID"  --role "Azure Digital Twins Data Owner"
+user_object_id=$(az ad signed-in-user show --query id -o tsv)
+az dt role-assignment create --dt-name "$digital_twin_name" --assignee "$user_object_id"  --role "Azure Digital Twins Data Owner"
 
 # Upload the sample-dtdl models
 echo -e "\nUploading sample-dtdl models"


### PR DESCRIPTION
This PR adds a deployment script that creates and initializes an Azure Digital Twin with a Twin model that matches the Smart Trailer Use case. Updates and adds some documentation.