### PR TITLE
Update security-audit.yml to build the test csproj for codeql

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -62,5 +62,6 @@ jobs:
           languages: ${{ matrix.language }}
       - name: Build MQTT Connector's Azure Function
         run: dotnet build cloud_connectors/resources/azure_function/src/function.csproj
+             dotnet build cloud_connectors/resources/azure_function/tests/MQTTConnectorAzureFunction.Tests.csproj
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,5 +1,6 @@
 name: Security Audit
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - main

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,6 +1,5 @@
 name: Security Audit
 on:
-  workflow_dispatch:
   pull_request:
     branches:
       - main
@@ -62,7 +61,8 @@ jobs:
         with:
           languages: ${{ matrix.language }}
       - name: Build MQTT Connector's Azure Function
-        run: dotnet build cloud_connectors/resources/azure_function/src/function.csproj
-             dotnet build cloud_connectors/resources/azure_function/tests/MQTTConnectorAzureFunction.Tests.csproj
+        run: |
+          dotnet build cloud_connectors/resources/azure_function/src/function.csproj
+          dotnet build cloud_connectors/resources/azure_function/tests/MQTTConnectorAzureFunction.Tests.csproj
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
Today, CodeQL only scans the cloud_connectors/resources/azure_function/src/function.csproj, but not the corresponding test project. Add dotnet build for the tests to the security audit workflow in order to have CodeQL scan those files as well.